### PR TITLE
just-semver v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 [![Build Status](https://github.com/Kevin-Lee/just-semver/workflows/Build%20All/badge.svg)](https://github.com/Kevin-Lee/just-semver/actions?workflow=Build+All)
 [![Release Status](https://github.com/Kevin-Lee/just-semver/workflows/Release/badge.svg)](https://github.com/Kevin-Lee/just-semver/actions?workflow=Release)
+[![Download](https://api.bintray.com/packages/kevinlee/maven/just-semver/images/download.svg)](https://bintray.com/kevinlee/maven/just-semver/_latestVersion)
 
 [![Coverage Status](https://coveralls.io/repos/github/Kevin-Lee/just-semver/badge.svg?branch=master)](https://coveralls.io/github/Kevin-Lee/just-semver?branch=master)
 
 Semantic Versioning (SemVer) for Scala
 
 # Get just-semver
-**It's not released yet.**
+```scala
+resolvers += "Just Repo" at "https://dl.bintray.com/kevinlee/maven"
+
+libraryDependencies += "io.kevinlee" %% "just-semver" % "0.1.0"
+```
 
 # How to Use
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ ThisBuild / developers   := List(
 ThisBuild / homepage := Some(url("https://github.com/Kevin-Lee/just-semver"))
 ThisBuild / scmInfo :=
     Some(ScmInfo(
-      url("https://github.com/Kevin-Lee/just-semver")
+        url("https://github.com/Kevin-Lee/just-semver")
       , "git@github.com:Kevin-Lee/just-semver.git"
     ))
 

--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,18 @@
+## [0.1.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2019-10-23
+
+### Done
+* Add `SemVer`
+* Remove `Identifier` (#18)
+* Refactor `compare` method for `SemVer` (#20)
+* Move instance member methods to the companion object (#22)
+* Remove `SequenceBasedVersion` (#26)
+* Change AlphaNumHyphen to Anh and AlphaNumHyphenGroup to Dsv (#28)
+* Add increase for `SemVer` (#36)
+
+### Fixed
+* `SemVer` compare does not work for `SemVer` containing `PreRelease` (#32)
+
+### Project Setting Changes
+* Change group id for publishing to `io.kevinlee` (#12)
+* Set up GitHub Actions for CI (#14)
+* Add PR templates (#24)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,7 +6,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectScalaVersion: String = "2.13.0"
+  val ProjectScalaVersion: String = "2.13.1"
   val CrossScalaVersions: Seq[String] = Seq("2.10.7", "2.11.12", "2.12.10", ProjectScalaVersion)
 
   val ProjectVersion: String = "0.1.0"


### PR DESCRIPTION
# `just-semver` v0.1.0
## [0.1.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2019-10-23

### Done
* Add `SemVer`
* Remove `Identifier` (#18)
* Refactor `compare` method for `SemVer` (#20)
* Move instance member methods to the companion object (#22)
* Remove `SequenceBasedVersion` (#26)
* Change AlphaNumHyphen to Anh and AlphaNumHyphenGroup to Dsv (#28)
* Add increase for `SemVer` (#36)

### Fixed
* `SemVer` compare does not work for `SemVer` containing `PreRelease` (#32)

### Project Setting Changes
* Change group id for publishing to `io.kevinlee` (#12)
* Set up GitHub Actions for CI (#14)
* Add PR templates (#24)
