### PR TITLE
GitHub Actions to sync to Maven Central after publish to Bintray

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,18 @@ jobs:
         echo "Run] sbt publish"
         echo 'sbt -J-Xmx2048m "; clean; +publish"'
         sbt -J-Xmx2048m "; clean; +publish"
+    - name: Sync to Maven Central
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}
+      run: |
+        PROJECT_VERSION="${GITHUB_REF#refs/tags/v}"
+        BINTRAY_SUBJECT=kevinlee
+        BINTRAY_REPO=maven
+        BINTRAY_PACKAGE=just-semver
+        echo "BINTRAY_SUBJECT: $BINTRAY_SUBJECT"
+        echo "   BINTRAY_REPO: $BINTRAY_REPO"
+        echo "BINTRAY_PACKAGE: $BINTRAY_PACKAGE"
+        echo "PROJECT_VERSION: $PROJECT_VERSION"
+        echo "Sync to Maven Central..."
+        curl --user $BINTRAY_USER:$BINTRAY_PASS -X POST "https://api.bintray.com/maven_central_sync/$BINTRAY_SUBJECT/$BINTRAY_REPO/$BINTRAY_PACKAGE/versions/$PROJECT_VERSION"


### PR DESCRIPTION
# Summary
GitHub Actions to sync to Maven Central after publish to Bintray