### PR TITLE
Upgraded - Scala and sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,9 @@ import kevinlee.sbt.SbtCommon.crossVersionProps
 import just.semver.SemVer, SemVer.{Major, Minor}
 import org.scoverage.coveralls.Imports.CoverallsKeys._
 
+val ProjectScalaVersion: String = "2.13.1"
+val CrossScalaVersions: Seq[String] = Seq("2.10.7", "2.11.12", "2.12.11", ProjectScalaVersion)
+
 ThisBuild / scalaVersion := ProjectScalaVersion
 ThisBuild / organization := "io.kevinlee"
 ThisBuild / version      := ProjectVersion
@@ -53,9 +56,12 @@ lazy val justSemVer = (project in file("."))
   , libraryDependencies ++=
       (scalaBinaryVersion.value match {
         case "2.10" =>
+          Seq("com.lihaoyi" % "ammonite" % "1.0.3" % Test cross CrossVersion.full)
           Seq.empty[ModuleID]
         case "2.11" =>
           Seq("com.lihaoyi" % "ammonite" % "1.6.7" % Test cross CrossVersion.full)
+        case "2.12" =>
+          Seq.empty[ModuleID] // TODO: add ammonite when it supports Scala 2.12.11
         case _ =>
           Seq("com.lihaoyi" % "ammonite" % "1.7.4" % Test cross CrossVersion.full)
       })
@@ -63,6 +69,8 @@ lazy val justSemVer = (project in file("."))
       (scalaBinaryVersion.value match {
         case "2.10" =>
           task(Seq.empty[File])
+        case "2.12" =>
+          task(Seq.empty[File]) // TODO: add ammonite when it supports Scala 2.12.11
         case _ =>
           task {
             val file = (sourceManaged in Test).value / "amm.scala"

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,9 +6,6 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectScalaVersion: String = "2.13.1"
-  val CrossScalaVersions: Seq[String] = Seq("2.10.7", "2.11.12", "2.12.10", ProjectScalaVersion)
-
   val ProjectVersion: String = "0.1.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ logLevel := sbt.Level.Warn
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 


### PR DESCRIPTION
# Upgraded - Scala and sbt plugin
* Scala `2.12.10` => `2.12.11`
* Since Ammonite does currently not support Scala `2.12.11`, it is disabled for Scala `2.12`.
* Upgraded: sbt-wartremover `2.4.3` => `2.4.5`