### PR TITLE
just-semver v0.1.1

### DIFF
--- a/changelogs/0.1.1.md
+++ b/changelogs/0.1.1.md
@@ -1,0 +1,6 @@
+## [0.1.1](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone2) - 2020-12-24 🎄
+
+### Done
+* Support Dotty (#58)
+* Support Scala `3.0.0-M1` and `3.0.0-M2` (#62)
+* Support Scala `3.0.0-M3` (#64)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,7 +6,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.1.0"
+  val ProjectVersion: String = "0.1.1"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# just-semver v0.1.1
## [0.1.1](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone2) - 2020-12-24 🎄

## Done
* Support Dotty (#58)
* Support Scala `3.0.0-M1` and `3.0.0-M2` (#62)
* Support Scala `3.0.0-M3` (#64)
