### PR TITLE
just-semver v0.1.2

### DIFF
--- a/changelogs/0.1.2.md
+++ b/changelogs/0.1.2.md
@@ -1,0 +1,6 @@
+## [0.1.2](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone3) - 2021-04-02
+
+### Done
+* Support Scala `3.0.0-RC1` (#69)
+* Support Scala `3.0.0-RC2` (#72)
+* Use `sbt-ci-release` to release (#75)


### PR DESCRIPTION
# just-semver v0.1.2
## [0.1.2](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone3) - 2021-04-02

### Done
* Support Scala `3.0.0-RC1` (#69)
* Support Scala `3.0.0-RC2` (#72)
* Use `sbt-ci-release` to release (#75)
