### PR TITLE
just-semver v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,4 @@
+## [0.2.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone4) - 2021-05-15
+
+### Done
+* Support Scala `3.0.0` (#78)


### PR DESCRIPTION
# just-semver v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone4) - 2021-05-15

### Done
* Support Scala `3.0.0` (#78)
