### PR TITLE
just-semver v0.3.0

### DIFF
--- a/changelogs/0.3.0.md
+++ b/changelogs/0.3.0.md
@@ -1,0 +1,7 @@
+## [0.3.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone5) - 2021-05-29
+
+### Done
+* Add some extension methods (#81)
+* Add a method to get `(Major, Minor, Patch)` (#82)
+* Make `just-semver` 0-dependency project (#86)
+  * Removed: `just-fp`


### PR DESCRIPTION
# just-semver v0.3.0
## [0.3.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone5) - 2021-05-29

### Done
* Add some extension methods (#81)
* Add a method to get `(Major, Minor, Patch)` (#82)
* Make `just-semver` 0-dependency project (#86)
  * Removed: `just-fp`
