### PR TITLE
Close #103 - Upgrade sbt-devoops from 2.6.0 to 2.14.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "1.6.1")
 addSbtPlugin("org.scoverage"   % "sbt-coveralls"   % "1.2.7")
 addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.9.29")
 
-val sbtDevOopsVersion = "2.6.0"
+val sbtDevOopsVersion = "2.14.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
Close #103 - Upgrade `sbt-devoops` from `2.6.0` to `2.14.0`