### PR TITLE
Fix #115 - Publish to s01.oss.sonatype.org (the new Maven central)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val justSemVer = (project in file("."))
     licenses                                := List("MIT" -> url("http://opensource.org/licenses/MIT")),
     console / initialCommands               := """import just.semver.SemVer""",
   )
+  .settings(mavenCentralPublishSettings)
 
 lazy val props =
   new {


### PR DESCRIPTION
# Summary
Fix #115 - Publish to `s01.oss.sonatype.org` (the new Maven central)