### PR TITLE
Close #129 - Replace Major, Minor and Patch value classes with opaque type in Scala 3

### DIFF
--- a/src/main/scala-2/just/semver/SemVer.scala
+++ b/src/main/scala-2/just/semver/SemVer.scala
@@ -20,9 +20,9 @@ final case class SemVer(
 
   override def compare(that: SemVer): Int = {
     (
-      this.major.major.compareTo(that.major.major),
-      this.minor.minor.compareTo(that.minor.minor),
-      this.patch.patch.compareTo(that.patch.patch)
+      this.major.value.compareTo(that.major.value),
+      this.minor.value.compareTo(that.minor.value),
+      this.patch.value.compareTo(that.patch.value)
     ) match {
       case (0, 0, 0) =>
         (this.pre, that.pre) match {
@@ -49,9 +49,26 @@ final case class SemVer(
 
 object SemVer {
 
-  final case class Major(major: Int) extends AnyVal
-  final case class Minor(minor: Int) extends AnyVal
-  final case class Patch(patch: Int) extends AnyVal
+  final case class Major(value: Int) extends AnyVal
+  object Major {
+    implicit class MajorOps(private val major0: Major) {
+      def major: Int = major0.value
+    }
+  }
+
+  final case class Minor(value: Int) extends AnyVal
+  object Minor {
+    implicit class MinorOps(private val minor0: Minor) {
+      def minor: Int = minor0.value
+    }
+  }
+
+  final case class Patch(value: Int) extends AnyVal
+  object Patch {
+    implicit class PatchOps(private val patch0: Patch) {
+      def patch: Int = patch0.value
+    }
+  }
 
   val major0: Major = Major(0)
   val minor0: Minor = Minor(0)
@@ -80,11 +97,11 @@ object SemVer {
     (semVer.major, semVer.minor, semVer.patch)
 
   def renderMajorMinorPatch(semVer: SemVer): String =
-    s"${semVer.major.major.toString}.${semVer.minor.minor.toString}.${semVer.patch.patch.toString}"
+    s"${semVer.major.value.toString}.${semVer.minor.value.toString}.${semVer.patch.value.toString}"
 
   def render(semVer: SemVer): String = semVer match {
     case SemVer(major, minor, patch, pre, buildMetadata) =>
-      val versionString        = s"${major.major.toString}.${minor.minor.toString}.${patch.patch.toString}"
+      val versionString        = s"${major.value.toString}.${minor.value.toString}.${patch.value.toString}"
       val additionalInfoString =
         (pre, buildMetadata) match {
           case (Some(p), Some(m)) =>
@@ -147,12 +164,12 @@ object SemVer {
     SemVer(major0, minor0, patch, None, None)
 
   def increaseMajor(semVer: SemVer): SemVer =
-    semVer.copy(major = Major(semVer.major.major + 1))
+    semVer.copy(major = Major(semVer.major.value + 1))
 
   def increaseMinor(semVer: SemVer): SemVer =
-    semVer.copy(minor = Minor(semVer.minor.minor + 1))
+    semVer.copy(minor = Minor(semVer.minor.value + 1))
 
   def increasePatch(semVer: SemVer): SemVer =
-    semVer.copy(patch = Patch(semVer.patch.patch + 1))
+    semVer.copy(patch = Patch(semVer.patch.value + 1))
 
 }

--- a/src/main/scala-3/just/semver/SemVer.scala
+++ b/src/main/scala-3/just/semver/SemVer.scala
@@ -21,9 +21,9 @@ final case class SemVer(
 
   override def compare(that: SemVer): Int = {
     (
-      this.major.major.compareTo(that.major.major),
-      this.minor.minor.compareTo(that.minor.minor),
-      this.patch.patch.compareTo(that.patch.patch)
+      this.major.value.compareTo(that.major.value),
+      this.minor.value.compareTo(that.minor.value),
+      this.patch.value.compareTo(that.patch.value)
     ) match {
       case (0, 0, 0) =>
         (this.pre, that.pre) match {
@@ -50,9 +50,47 @@ final case class SemVer(
 
 object SemVer {
 
-  final case class Major(major: Int) extends AnyVal
-  final case class Minor(minor: Int) extends AnyVal
-  final case class Patch(patch: Int) extends AnyVal
+  type Major = Major.Major
+  object Major {
+    opaque type Major = Int
+    def apply(major: Int): Major         = major
+    def unapply(major: Major): Some[Int] = Some(major)
+
+    given majorCanEqual: CanEqual[Major, Major] = CanEqual.derived
+
+    extension (major0: Major) {
+      def value: Int = major0
+      def major: Int = major0
+    }
+  }
+
+  type Minor = Minor.Minor
+  object Minor {
+    opaque type Minor = Int
+    def apply(minor: Int): Minor         = minor
+    def unapply(minor: Minor): Some[Int] = Some(minor)
+
+    given minorCanEqual: CanEqual[Minor, Minor] = CanEqual.derived
+
+    extension (minor0: Minor) {
+      def value: Int = minor0
+      def minor: Int = minor0
+    }
+  }
+
+  type Patch = Patch.Patch
+  object Patch {
+    opaque type Patch = Int
+    def apply(patch: Int): Patch         = patch
+    def unapply(patch: Patch): Some[Int] = Some(patch)
+
+    given patchCanEqual: CanEqual[Patch, Patch] = CanEqual.derived
+
+    extension (patch0: Patch) {
+      def value: Int = patch0
+      def patch: Int = patch0
+    }
+  }
 
   val major0: Major = Major(0)
   val minor0: Minor = Minor(0)
@@ -65,11 +103,11 @@ object SemVer {
       (semVer.major, semVer.minor, semVer.patch)
 
     def renderMajorMinorPatch: String =
-      s"${semVer.major.major.toString}.${semVer.minor.minor.toString}.${semVer.patch.patch.toString}"
+      s"${semVer.major.value.toString}.${semVer.minor.value.toString}.${semVer.patch.value.toString}"
 
     def render: String = semVer match {
       case SemVer(major, minor, patch, pre, buildMetadata) =>
-        val versionString        = s"${major.major.toString}.${minor.minor.toString}.${patch.patch.toString}"
+        val versionString        = s"${major.value.toString}.${minor.value.toString}.${patch.value.toString}"
         val additionalInfoString =
           (pre, buildMetadata) match {
             case (Some(p), Some(m)) =>
@@ -140,12 +178,12 @@ object SemVer {
     SemVer(major0, minor0, patch, None, None)
 
   def increaseMajor(semVer: SemVer): SemVer =
-    semVer.copy(major = Major(semVer.major.major + 1))
+    semVer.copy(major = Major(semVer.major.value + 1))
 
   def increaseMinor(semVer: SemVer): SemVer =
-    semVer.copy(minor = Minor(semVer.minor.minor + 1))
+    semVer.copy(minor = Minor(semVer.minor.value + 1))
 
   def increasePatch(semVer: SemVer): SemVer =
-    semVer.copy(patch = Patch(semVer.patch.patch + 1))
+    semVer.copy(patch = Patch(semVer.patch.value + 1))
 
 }

--- a/src/test/scala/just/semver/SemVerSpec.scala
+++ b/src/test/scala/just/semver/SemVerSpec.scala
@@ -649,13 +649,13 @@ object SemVerSpec extends Properties {
     patch <- Gens.genPatch.log("major")
   } yield {
     SemVer.semVer(major, minor, patch).asRight[ParseError] ====
-      SemVer.parse(s"${major.major.toString}.${minor.minor.toString}.${patch.patch.toString}")
+      SemVer.parse(s"${major.value.toString}.${minor.value.toString}.${patch.value.toString}")
   }
 
   def testSemVerIncreaseMajor: Property = for {
     v <- Gens.genSemVer.log("v")
   } yield {
-    val expected = v.copy(major = Major(v.major.major + 1))
+    val expected = v.copy(major = Major(v.major.value + 1))
     val actual   = SemVer.increaseMajor(v)
     actual ==== expected
   }
@@ -663,7 +663,7 @@ object SemVerSpec extends Properties {
   def testSemVerIncreaseMinor: Property = for {
     v <- Gens.genSemVer.log("v")
   } yield {
-    val expected = v.copy(minor = Minor(v.minor.minor + 1))
+    val expected = v.copy(minor = Minor(v.minor.value + 1))
     val actual   = SemVer.increaseMinor(v)
     actual ==== expected
   }
@@ -671,7 +671,7 @@ object SemVerSpec extends Properties {
   def testSemVerIncreasePatch: Property = for {
     v <- Gens.genSemVer.log("v")
   } yield {
-    val expected = v.copy(patch = Patch(v.patch.patch + 1))
+    val expected = v.copy(patch = Patch(v.patch.value + 1))
     val actual   = SemVer.increasePatch(v)
     actual ==== expected
   }

--- a/src/test/scala/just/semver/matcher/Gens.scala
+++ b/src/test/scala/just/semver/matcher/Gens.scala
@@ -38,14 +38,14 @@ object Gens {
     one <- Gen.element1(1, 2, 4)
     (m, n, p) = ((4 & one) >> 2, (2 & one) >> 1, 1 & one)
     v2     <- SemVerGens.genSemVerWithRange(
-                Range.linear(v1.major.major + m, v1.major.major + 100),
-                Range.linear(v1.minor.minor + n, v1.minor.minor + 100),
-                Range.linear(v1.patch.patch + p, v1.patch.patch + 100)
+                Range.linear(v1.major.value + m, v1.major.value + 100),
+                Range.linear(v1.minor.value + n, v1.minor.value + 100),
+                Range.linear(v1.patch.value + p, v1.patch.value + 100)
               )
     semVer <- SemVerGens.genSemVerWithRange(
-                Range.linear(v1.major.major, v2.major.major),
-                Range.linear(v1.minor.minor, v2.minor.minor),
-                Range.linear(v1.patch.patch, v2.patch.patch)
+                Range.linear(v1.major.value, v2.major.value),
+                Range.linear(v1.minor.value, v2.minor.value),
+                Range.linear(v1.patch.value, v2.patch.value)
               )
   } yield (SemVerMatcher.range(v1, v2), v1.copy(major = semVer.major, minor = semVer.minor, patch = semVer.patch))
 
@@ -90,9 +90,9 @@ object Gens {
     inclusive match {
       case false =>
         val semVer = v1SemVer.copy(
-          major = SemVer.Major(v1SemVer.major.major + m),
-          minor = SemVer.Minor(v1SemVer.minor.minor + n),
-          patch = SemVer.Patch(v1SemVer.patch.patch + p)
+          major = SemVer.Major(v1SemVer.major.value + m),
+          minor = SemVer.Minor(v1SemVer.minor.value + n),
+          patch = SemVer.Patch(v1SemVer.patch.value + p)
         )
         val v1     = SemVerComparison(
           ComparisonOperator.gt,
@@ -102,17 +102,17 @@ object Gens {
           ComparisonOperator.lt,
           v1.semVer
             .copy(
-              major = SemVer.Major(semVer.major.major + m),
-              minor = SemVer.Minor(semVer.minor.minor + n),
-              patch = SemVer.Patch(semVer.patch.patch + p)
+              major = SemVer.Major(semVer.major.value + m),
+              minor = SemVer.Minor(semVer.minor.value + n),
+              patch = SemVer.Patch(semVer.patch.value + p)
             )
         )
         (v1, v2, semVer)
       case true =>
         val semVer = v1SemVer.copy(
-          major = SemVer.Major(v1SemVer.major.major + m),
-          minor = SemVer.Minor(v1SemVer.minor.minor + n),
-          patch = SemVer.Patch(v1SemVer.patch.patch + p)
+          major = SemVer.Major(v1SemVer.major.value + m),
+          minor = SemVer.Minor(v1SemVer.minor.value + n),
+          patch = SemVer.Patch(v1SemVer.patch.value + p)
         )
         val v1     = SemVerComparison(
           ComparisonOperator.ge,
@@ -122,9 +122,9 @@ object Gens {
           ComparisonOperator.le,
           v1.semVer
             .copy(
-              major = SemVer.Major(semVer.major.major + m),
-              minor = SemVer.Minor(semVer.minor.minor + n),
-              patch = SemVer.Patch(semVer.patch.patch + p)
+              major = SemVer.Major(semVer.major.value + m),
+              minor = SemVer.Minor(semVer.minor.value + n),
+              patch = SemVer.Patch(semVer.patch.value + p)
             )
         )
         (v1, v2, semVer)

--- a/src/test/scala/just/semver/matcher/SemVerMatcherSpec.scala
+++ b/src/test/scala/just/semver/matcher/SemVerMatcherSpec.scala
@@ -57,9 +57,9 @@ object SemVerMatcherSpec extends Properties {
     val matcher        = SemVerMatcher.range(v1, v2)
 
     val semVer2 = v2.copy(
-      major = SemVer.Major(v2.major.major + majorMoreLess),
-      minor = SemVer.Minor(v2.minor.minor + minorMoreLess),
-      patch = SemVer.Patch(v2.patch.patch + patchMoreLess1)
+      major = SemVer.Major(v2.major.value + majorMoreLess),
+      minor = SemVer.Minor(v2.minor.value + minorMoreLess),
+      patch = SemVer.Patch(v2.patch.value + patchMoreLess1)
     )
 
     Result.all(


### PR DESCRIPTION
# Summary
Close #129 - Replace `Major`, `Minor` and `Patch` value classes with `opaque type` in Scala 3