### PR TITLE
Close #131 - Rename `SemVer.parseUnsafe` to `SemVer.unsafeParse` to keep the consistency with other unsafe methods

### DIFF
--- a/src/main/scala-2/just/semver/SemVer.scala
+++ b/src/main/scala-2/just/semver/SemVer.scala
@@ -116,13 +116,15 @@ object SemVer {
       versionString + additionalInfoString
   }
 
-  def parseUnsafe(version: String): SemVer =
+  def unsafeParse(version: String): SemVer =
     parse(version) match {
       case Right(semVer) =>
         semVer
       case Left(error) =>
         sys.error(ParseError.render(error))
     }
+
+  def parseUnsafe(version: String): SemVer = unsafeParse(version)
 
   def parse(version: String): Either[ParseError, SemVer] = version match {
     case semVerRegex(major, minor, patch, pre, meta) =>

--- a/src/main/scala-3/just/semver/SemVer.scala
+++ b/src/main/scala-3/just/semver/SemVer.scala
@@ -130,13 +130,15 @@ object SemVer {
         .matches(semVer)
   }
 
-  def parseUnsafe(version: String): SemVer =
+  def unsafeParse(version: String): SemVer =
     parse(version) match {
       case Right(semVer) =>
         semVer
       case Left(error) =>
         sys.error(ParseError.render(error))
     }
+
+  def parseUnsafe(version: String): SemVer = unsafeParse(version)
 
   def parse(version: String): Either[ParseError, SemVer] = version match {
     case semVerRegex(major, minor, patch, pre, meta) =>

--- a/src/test/scala/just/semver/SemVerSpec.scala
+++ b/src/test/scala/just/semver/SemVerSpec.scala
@@ -849,7 +849,7 @@ object SemVerSpec extends Properties {
     semVer <- Gens.genSemVer.log("semVer")
   } yield {
     val input    = semVer.render
-    val actual   = SemVer.parseUnsafe(input)
+    val actual   = SemVer.unsafeParse(input)
     val expected = semVer
     actual ==== expected
   }
@@ -858,73 +858,73 @@ object SemVerSpec extends Properties {
 
     def testExample1: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.0").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
+        .assert(SemVer.unsafeParse("1.0.0").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.0.0) failed")
     }
 
     def testExample2: Result = {
       Result
-        .assert(SemVer.parseUnsafe("2.0.0").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
+        .assert(SemVer.unsafeParse("2.0.0").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(2.0.0) failed")
     }
 
     def testExample3: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.1").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
+        .assert(SemVer.unsafeParse("1.0.1").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.0.1) failed")
     }
 
     def testExample4: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.999.999").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
+        .assert(SemVer.unsafeParse("1.999.999").matches(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.999.999) failed")
     }
 
     def testExample5: Result = {
       Result
-        .diff(SemVer.parseUnsafe("1.0.0").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")), false)(_ === _)
+        .diff(SemVer.unsafeParse("1.0.0").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")), false)(_ === _)
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.0.0) failed")
     }
 
     def testExample6: Result = {
       Result
-        .diff(SemVer.parseUnsafe("2.0.0").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")), false)(_ === _)
+        .diff(SemVer.unsafeParse("2.0.0").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")), false)(_ === _)
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(2.0.0) failed")
     }
 
     def testExample7: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.1").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")))
+        .assert(SemVer.unsafeParse("1.0.1").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")))
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.0.1) failed")
     }
 
     def testExample8: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.999.999").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")))
+        .assert(SemVer.unsafeParse("1.999.999").matches(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0")))
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.999.999) failed")
     }
 
     def testExample9: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.0").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
+        .assert(SemVer.unsafeParse("1.0.0").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.0.0) failed")
     }
 
     def testExample10: Result = {
       Result
-        .assert(SemVer.parseUnsafe("2.0.0").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
+        .assert(SemVer.unsafeParse("2.0.0").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(2.0.0) failed")
     }
 
     def testExample11: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.1").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
+        .assert(SemVer.unsafeParse("1.0.1").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.0.1) failed")
     }
 
     def testExample12: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.999.999").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
+        .assert(SemVer.unsafeParse("1.999.999").matches(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.999.999) failed")
     }
 
@@ -1113,73 +1113,73 @@ object SemVerSpec extends Properties {
 
     def testExample1: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.0").unsafeMatches("1.0.0 - 2.0.0"))
+        .assert(SemVer.unsafeParse("1.0.0").unsafeMatches("1.0.0 - 2.0.0"))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.0.0) failed")
     }
 
     def testExample2: Result = {
       Result
-        .assert(SemVer.parseUnsafe("2.0.0").unsafeMatches("1.0.0 - 2.0.0"))
+        .assert(SemVer.unsafeParse("2.0.0").unsafeMatches("1.0.0 - 2.0.0"))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(2.0.0) failed")
     }
 
     def testExample3: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.1").unsafeMatches("1.0.0 - 2.0.0"))
+        .assert(SemVer.unsafeParse("1.0.1").unsafeMatches("1.0.0 - 2.0.0"))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.0.1) failed")
     }
 
     def testExample4: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.999.999").unsafeMatches("1.0.0 - 2.0.0"))
+        .assert(SemVer.unsafeParse("1.999.999").unsafeMatches("1.0.0 - 2.0.0"))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.999.999) failed")
     }
 
     def testExample5: Result = {
       Result
-        .diff(SemVer.parseUnsafe("1.0.0").unsafeMatches(">1.0.0 <2.0.0"), false)(_ === _)
+        .diff(SemVer.unsafeParse("1.0.0").unsafeMatches(">1.0.0 <2.0.0"), false)(_ === _)
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.0.0) failed")
     }
 
     def testExample6: Result = {
       Result
-        .diff(SemVer.parseUnsafe("2.0.0").unsafeMatches(">1.0.0 <2.0.0"), false)(_ === _)
+        .diff(SemVer.unsafeParse("2.0.0").unsafeMatches(">1.0.0 <2.0.0"), false)(_ === _)
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(2.0.0) failed")
     }
 
     def testExample7: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.1").unsafeMatches(">1.0.0 <2.0.0"))
+        .assert(SemVer.unsafeParse("1.0.1").unsafeMatches(">1.0.0 <2.0.0"))
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.0.1) failed")
     }
 
     def testExample8: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.999.999").unsafeMatches(">1.0.0 <2.0.0"))
+        .assert(SemVer.unsafeParse("1.999.999").unsafeMatches(">1.0.0 <2.0.0"))
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.999.999) failed")
     }
 
     def testExample9: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.0").unsafeMatches(">=1.0.0 <=2.0.0"))
+        .assert(SemVer.unsafeParse("1.0.0").unsafeMatches(">=1.0.0 <=2.0.0"))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.0.0) failed")
     }
 
     def testExample10: Result = {
       Result
-        .assert(SemVer.parseUnsafe("2.0.0").unsafeMatches(">=1.0.0 <=2.0.0"))
+        .assert(SemVer.unsafeParse("2.0.0").unsafeMatches(">=1.0.0 <=2.0.0"))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(2.0.0) failed")
     }
 
     def testExample11: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.0.1").unsafeMatches(">=1.0.0 <=2.0.0"))
+        .assert(SemVer.unsafeParse("1.0.1").unsafeMatches(">=1.0.0 <=2.0.0"))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.0.1) failed")
     }
 
     def testExample12: Result = {
       Result
-        .assert(SemVer.parseUnsafe("1.999.999").unsafeMatches(">=1.0.0 <=2.0.0"))
+        .assert(SemVer.unsafeParse("1.999.999").unsafeMatches(">=1.0.0 <=2.0.0"))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.999.999) failed")
     }
 

--- a/src/test/scala/just/semver/matcher/SemVerMatchersSpec.scala
+++ b/src/test/scala/just/semver/matcher/SemVerMatchersSpec.scala
@@ -201,73 +201,73 @@ object SemVerMatchersSpec extends Properties {
 
     def testExample1: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.parseUnsafe("1.0.0")))
+        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.unsafeParse("1.0.0")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.0.0) failed")
     }
 
     def testExample2: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.parseUnsafe("2.0.0")))
+        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.unsafeParse("2.0.0")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(2.0.0) failed")
     }
 
     def testExample3: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.parseUnsafe("1.0.1")))
+        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.unsafeParse("1.0.1")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.0.1) failed")
     }
 
     def testExample4: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.parseUnsafe("1.999.999")))
+        .assert(SemVerMatchers.unsafeParse("1.0.0 - 2.0.0").matches(SemVer.unsafeParse("1.999.999")))
         .log("SemVerMatchers(1.0.0 - 2.0.0).matches(1.999.999) failed")
     }
 
     def testExample5: Result = {
       Result
-        .diff(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.parseUnsafe("1.0.0")), false)(_ === _)
+        .diff(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.unsafeParse("1.0.0")), false)(_ === _)
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.0.0) failed")
     }
 
     def testExample6: Result = {
       Result
-        .diff(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.parseUnsafe("2.0.0")), false)(_ === _)
+        .diff(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.unsafeParse("2.0.0")), false)(_ === _)
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(2.0.0) failed")
     }
 
     def testExample7: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.parseUnsafe("1.0.1")))
+        .assert(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.unsafeParse("1.0.1")))
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.0.1) failed")
     }
 
     def testExample8: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.parseUnsafe("1.999.999")))
+        .assert(SemVerMatchers.unsafeParse(">1.0.0 <2.0.0").matches(SemVer.unsafeParse("1.999.999")))
         .log("SemVerMatchers(>1.0.0 <2.0.0).matches(1.999.999) failed")
     }
 
     def testExample9: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.parseUnsafe("1.0.0")))
+        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.unsafeParse("1.0.0")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.0.0) failed")
     }
 
     def testExample10: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.parseUnsafe("2.0.0")))
+        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.unsafeParse("2.0.0")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(2.0.0) failed")
     }
 
     def testExample11: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.parseUnsafe("1.0.1")))
+        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.unsafeParse("1.0.1")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.0.1) failed")
     }
 
     def testExample12: Result = {
       Result
-        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.parseUnsafe("1.999.999")))
+        .assert(SemVerMatchers.unsafeParse(">=1.0.0 <=2.0.0").matches(SemVer.unsafeParse("1.999.999")))
         .log("SemVerMatchers(>=1.0.0 <=2.0.0).matches(1.999.999) failed")
     }
 


### PR DESCRIPTION
# Summary
Close #131 - Rename `SemVer.parseUnsafe` to `SemVer.unsafeParse` to keep the consistency with other unsafe methods