### PR TITLE
Simplify rendering `List[SemVerMatcher.ParseError]` - now `SemVerMatchers.ParseErrors` contains `List[SemVerMatcher.ParseError]`

### DIFF
--- a/src/main/scala-2/just/semver/matcher/SemVerMatchers.scala
+++ b/src/main/scala-2/just/semver/matcher/SemVerMatchers.scala
@@ -10,9 +10,9 @@ final case class SemVerMatchers(matchers: SemVerMatchers.Or)
 object SemVerMatchers extends Compat {
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion", "org.wartremover.warts.ListAppend"))
-  def parse(selector: String): Either[List[SemVerMatcher.ParseError], SemVerMatchers] = {
+  def parse(selector: String): Either[SemVerMatchers.ParseErrors, SemVerMatchers] = {
     @SuppressWarnings(Array("org.wartremover.warts.JavaSerializable", "org.wartremover.warts.Serializable"))
-    def each(s: String): Either[List[SemVerMatcher.ParseError], List[SemVerMatcher]] = {
+    def each(s: String): Either[(SemVerMatcher.ParseError, List[SemVerMatcher.ParseError]), List[SemVerMatcher]] = {
       val spaced      = s.split("\\s+")
       val hyphenIndex = spaced.indexWhere(_ === "-")
       if (hyphenIndex >= 0) {
@@ -48,46 +48,50 @@ object SemVerMatchers extends Compat {
                     (failed, success :+ parsed)
                 }
 
-            if (failed.isEmpty) {
-              if (after.isEmpty) {
-                Right(success)
-              } else {
-                each(after.mkString(" ")) match {
-                  case Right(rest) =>
-                    Right(success ++ rest)
-                  case Left(err) =>
-                    Left(failed ++ err)
+            failed match {
+              case Nil =>
+                if (after.isEmpty) {
+                  Right(success)
+                } else {
+                  each(after.mkString(" "))
+                    .map(rest => success ++ rest)
                 }
-              }
-            } else {
-              if (after.isEmpty) {
-                Left(failed)
-              } else {
-                each(after.mkString(" ")) match {
-                  case Right(_) =>
-                    Left(failed)
-                  case Left(err) =>
-                    Left(failed ++ err)
+
+              case failed :: failedMore =>
+                if (after.isEmpty) {
+                  Left((failed, failedMore))
+                } else {
+                  each(after.mkString(" ")) match {
+                    case Right(_) =>
+                      Left((failed, failedMore))
+                    case Left((err, errs)) =>
+                      Left((failed, failedMore ++ (err :: errs)))
+                  }
                 }
-              }
 
             }
+
           case (Right(before), Left(err)) =>
             Left(
-              List(
-                SemVerMatcher.ParseError.rangeParseFailure("Parsing 'to' in range failed: ", List(err), Some(before))
+              (
+                SemVerMatcher.ParseError.rangeParseFailure("Parsing 'to' in range failed: ", List(err), Some(before)),
+                Nil
               )
             )
           case (Left(err), Right(end)) =>
             Left(
-              List(SemVerMatcher.ParseError.rangeParseFailure("Parsing 'from' in range failed: ", List(err), Some(end)))
+              (
+                SemVerMatcher.ParseError.rangeParseFailure("Parsing 'from' in range failed: ", List(err), Some(end)),
+                Nil
+              )
             )
           case (Left(err1), Left(err2)) =>
             Left(
-              List(
+              (
                 SemVerMatcher
                   .ParseError
-                  .rangeParseFailure("Parsing both 'from' and 'to' in range failed: ", List(err1, err2), None)
+                  .rangeParseFailure("Parsing both 'from' and 'to' in range failed: ", List(err1, err2), None),
+                Nil
               )
             )
         }
@@ -108,12 +112,13 @@ object SemVerMatchers extends Compat {
               case ((failed, success), Right(parsed)) =>
                 (failed, success :+ parsed)
             }
-        if (failed.isEmpty) {
-          Right(success)
-        } else {
-          Left(failed)
-        }
 
+        failed match {
+          case Nil =>
+            Right(success)
+          case err :: errs =>
+            Left((err, errs))
+        }
       }
 
     }
@@ -124,18 +129,19 @@ object SemVerMatchers extends Compat {
       .foldLeft((List.empty[SemVerMatcher.ParseError], List.empty[And])) {
         case ((failed, success), Right(ands)) =>
           (failed, success :+ And(ands))
-        case ((failed, success), Left(errs)) =>
-          (failed ++ errs, success)
+        case ((failed, success), Left((err, errs))) =>
+          (failed ++ (err :: errs), success)
       }
-    if (failed.isEmpty) {
-      Right(SemVerMatchers(Or(success)))
-    } else {
-      Left(failed)
+    failed match {
+      case Nil =>
+        Right(SemVerMatchers(Or(success)))
+      case err :: errs =>
+        Left(ParseErrors(err, errs))
     }
   }
 
   def unsafeParse(matchers: String): SemVerMatchers =
-    parse(matchers).fold(errs => sys.error(errs.map(_.render).mkString(", ")), identity)
+    parse(matchers).fold(errs => sys.error(errs.render), identity)
 
   final case class Or(value: List[And]) extends AnyVal
   final case class And(value: List[SemVerMatcher]) extends AnyVal
@@ -164,4 +170,19 @@ object SemVerMatchers extends Compat {
 
   }
 
+  final case class ParseErrors(
+    private val error: SemVerMatcher.ParseError,
+    private val errors: List[SemVerMatcher.ParseError]
+  )
+  object ParseErrors {
+
+    implicit class ParseErrorsOps(private val parseErrors: ParseErrors) extends AnyVal {
+
+      /** Returns List[SemVerMatcher.ParseError]. The List returned is guaranteed non-empty.
+        */
+      def allErrors: List[SemVerMatcher.ParseError] = parseErrors.error :: parseErrors.errors
+
+      def render: String = allErrors.map(_.render).mkString("[", ", ", "]")
+    }
+  }
 }

--- a/src/test/scala/just/semver/matcher/SemVerMatchersSpec.scala
+++ b/src/test/scala/just/semver/matcher/SemVerMatchersSpec.scala
@@ -103,7 +103,7 @@ object SemVerMatchersSpec extends Properties {
         Result
           .failure
           .log(
-            s"""${errs.mkString("\n")}
+            s"""${errs.render}
                |input: $input
                |""".stripMargin
           )
@@ -127,11 +127,11 @@ object SemVerMatchersSpec extends Properties {
       case Left(errs) =>
         Result.all(
           List(
-            Result.assert(errs.nonEmpty).log("SemVerMatchers.parse(invalid) failed but no errors found"),
+            Result.assert(errs.allErrors.nonEmpty).log("SemVerMatchers.parse(invalid) failed but no errors found"),
             Result
-              .assert(errs.map(_.render).forall(s => s.contains("ParseError") && s.contains("at 0")))
+              .assert(errs.allErrors.map(_.render).forall(s => s.contains("ParseError") && s.contains("at 0")))
               .log(s"""SemVerMatchers.parse(invalid) failed but doesn't have expected ParseError.
-                  |> Errors: ${errs.map(_.render).mkString("[\n>   - ", "\n>   - ", "\n> ]")}
+                  |> Errors: ${errs.allErrors.map(_.render).mkString("[\n>   - ", "\n>   - ", "\n> ]")}
                   |""".stripMargin)
           )
         )


### PR DESCRIPTION
# Summary
Simplify rendering `List[SemVerMatcher.ParseError]` - now `SemVerMatchers.ParseErrors` contains `List[SemVerMatcher.ParseError]`