### PR TITLE
Simplify `Either[SemVerMatchers.ParseErrors, SemVerMatchers]` => `Either[just.semver.ParseError, SemVerMatchers]`

### DIFF
--- a/src/main/scala-2/just/semver/ParseError.scala
+++ b/src/main/scala-2/just/semver/ParseError.scala
@@ -1,5 +1,7 @@
 package just.semver
 
+import just.semver.matcher.SemVerMatchers
+
 /** @author Kevin Lee
   * @since 2018-10-21
   */
@@ -18,6 +20,8 @@ object ParseError {
   final case class CombinedParseError(preReleaseError: ParseError, buildMetadataError: ParseError) extends ParseError
 
   final case class InvalidVersionStringError(value: String) extends ParseError
+
+  final case class SemVerMatchersParseErrors(error: matcher.SemVerMatchers.ParseErrors) extends ParseError
 
   def invalidAlphaNumHyphenError(c: Char, rest: List[Char]): ParseError =
     InvalidAlphaNumHyphenError(c, rest)
@@ -42,6 +46,8 @@ object ParseError {
 
   def invalidVersionStringError(value: String): ParseError =
     InvalidVersionStringError(value)
+
+  def semVerMatchersParseErrors(error: SemVerMatchers.ParseErrors): ParseError = SemVerMatchersParseErrors(error)
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   def render(parseError: ParseError): String = parseError match {
@@ -68,6 +74,9 @@ object ParseError {
 
     case InvalidVersionStringError(value) =>
       s"Invalid SemVer String. value: $value"
+
+    case SemVerMatchersParseErrors(error) =>
+      s"Error when parsing SemVerMatchers: ${error.render}"
   }
 
   implicit final class ParseErrorOps(private val parseError: ParseError) extends AnyVal {

--- a/src/main/scala-2/just/semver/matcher/SemVerMatchers.scala
+++ b/src/main/scala-2/just/semver/matcher/SemVerMatchers.scala
@@ -1,7 +1,7 @@
 package just.semver.matcher
 
 import just.Common._
-import just.semver.{Compat, SemVer}
+import just.semver.{Compat, SemVer, ParseError => SemVerParseError}
 
 /** @author Kevin Lee
   * @since 2022-04-07
@@ -183,6 +183,11 @@ object SemVerMatchers extends Compat {
       def allErrors: List[SemVerMatcher.ParseError] = parseErrors.error :: parseErrors.errors
 
       def render: String = allErrors.map(_.render).mkString("[", ", ", "]")
+    }
+
+    implicit class ParseErrorsOrSemVerMatchersOps(private val eth: Either[ParseErrors, SemVerMatchers]) extends AnyVal {
+      def toSemVerParseError: Either[SemVerParseError, SemVerMatchers] =
+        eth.left.map(SemVerParseError.semVerMatchersParseErrors)
     }
   }
 }

--- a/src/main/scala-3/just/semver/ParseError.scala
+++ b/src/main/scala-3/just/semver/ParseError.scala
@@ -1,5 +1,7 @@
 package just.semver
 
+import just.semver.matcher.SemVerMatchers
+
 /** @author Kevin Lee
   * @since 2018-10-21
   */
@@ -12,6 +14,7 @@ enum ParseError derives CanEqual {
   case BuildMetadataParseError(parseError: ParseError)
   case CombinedParseError(preReleaseError: ParseError, buildMetadataError: ParseError)
   case InvalidVersionStringError(value: String)
+  case SemVerMatchersParseErrors(error: matcher.SemVerMatchers.ParseErrors)
 }
 
 object ParseError {
@@ -39,6 +42,9 @@ object ParseError {
   def invalidVersionStringError(value: String): ParseError =
     InvalidVersionStringError(value)
 
+  def semVerMatchersParseErrors(error: SemVerMatchers.ParseErrors): ParseError =
+    SemVerMatchersParseErrors(error)
+
   extension (parseError: ParseError) {
     def render: String = parseError match {
       case InvalidAlphaNumHyphenError(c, rest) =>
@@ -64,6 +70,9 @@ object ParseError {
 
       case InvalidVersionStringError(value) =>
         s"Invalid SemVer String. value: $value"
+
+      case SemVerMatchersParseErrors(error) =>
+        s"Error when parsing SemVerMatchers: ${error.render}"
     }
   }
 

--- a/src/main/scala-3/just/semver/matcher/SemVerMatchers.scala
+++ b/src/main/scala-3/just/semver/matcher/SemVerMatchers.scala
@@ -2,6 +2,7 @@ package just.semver.matcher
 
 import just.Common._
 import just.semver.{Compat, SemVer}
+import just.semver.{ParseError as SemVerParseError}
 
 /** @author Kevin Lee
   * @since 2022-04-07
@@ -206,6 +207,11 @@ object SemVerMatchers extends Compat {
       def allErrors: List[SemVerMatcher.ParseError] = parseErrors.error :: parseErrors.errors
 
       def render: String = allErrors.map(_.render).mkString("[", ", ", "]")
+    }
+
+    extension (eth: Either[ParseErrors, SemVerMatchers]) {
+      def toSemVerParseError: Either[SemVerParseError, SemVerMatchers] =
+        eth.left.map(SemVerParseError.semVerMatchersParseErrors)
     }
   }
 }


### PR DESCRIPTION
# Summary
Simplify `Either[SemVerMatchers.ParseErrors, SemVerMatchers]` => `Either[just.semver.ParseError, SemVerMatchers]`