### PR TITLE
just-semver v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,13 @@
+## [0.4.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2022-04-11
+
+### Done
+* Rename `SemVer.parseUnsafe` to `SemVer.unsafeParse` to keep the consistency with other `unsafe` methods (#131)
+* Replace `Major`, `Minor` and `Patch` value classes with `opaque type` in Scala 3 (#129)
+* Add `SemVerMatchers`, `SemVer.matches()` and `SemVer.unsafeMatches()` (#125)
+* Remove `can-equal` (#102)
+* Use Scala 3 syntax (#91)
+***
+* Publish to `s01.oss.sonatype.org` (the new Maven central) (#115)
+* Stop uploading artifacts to GitHub Release (#113)
+* Set up Codecov in GitHub Actions (#111)
+* Upgrade `sbt-devoops` from `2.6.0` to `2.14.0` (#103) `2.14.0` => `2.15.0` (#121) `2.15.0` => `2.16.0` (#126)


### PR DESCRIPTION
# just-semver v0.4.0
## [0.4.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2022-04-11

### Done
* Rename `SemVer.parseUnsafe` to `SemVer.unsafeParse` to keep the consistency with other `unsafe` methods (#131)
* Replace `Major`, `Minor` and `Patch` value classes with `opaque type` in Scala 3 (#129)
* Add `SemVerMatchers`, `SemVer.matches()` and `SemVer.unsafeMatches()` (#125)
* Remove `can-equal` (#102)
* Use Scala 3 syntax (#91)
***
* Publish to `s01.oss.sonatype.org` (the new Maven central) (#115)
* Stop uploading artifacts to GitHub Release (#113)
* Set up Codecov in GitHub Actions (#111)
* Upgrade `sbt-devoops` from `2.6.0` to `2.14.0` (#103) `2.14.0` => `2.15.0` (#121) `2.15.0` => `2.16.0` (#126)
