### PR TITLE
just-semver v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,44 @@
+## [0.5.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2022-06-11
+
+### Done
+* Add decimal version `DecVer` (`major.minor`) (#140)
+  ```scala
+  import just.decver.DecVer
+  
+  val decVer1 = DecVer.parse("1.17")
+  // Either[DecVer.ParseError, DecVer] = Right(DecVer(1,17))
+  
+  decVer1.map(_.render)
+  // Either[DecVer.ParseError, String] = Right(1.17)
+  
+  val decVer2 = DecVer.unsafeParse("1.17")
+  // DecVer = DecVer(1,17)
+  
+  decVer2.render
+  // String = 1.17
+  
+  val semVer = decVer2.toSemVer
+  // just.semver.SemVer = SemVer(1,17,0,None,None)
+  
+  semVer.toDecVer
+  // just.decver.DecVer = DecVer(1,17)
+  
+  DecVer.unsafeParse("1.16") < DecVer.unsafeParse("1.17")
+  // Boolean = true
+  
+  DecVer.unsafeParse("1.16") == DecVer.unsafeParse("1.17")
+  // Boolean = false
+  
+  DecVer.unsafeParse("1.16") > DecVer.unsafeParse("1.17")
+  // Boolean = false
+  
+  val decVer = DecVer.unsafeParse("1.0")
+  // DecVer = DecVer(1,0)
+  
+  decVer.increaseMinor
+  // DecVer = DecVer(1,1)
+  
+  decVer.increaseMajor
+  // DecVer = DecVer(2,0)
+  ```
+* Set up WartRemover for Scala 3 (#138)


### PR DESCRIPTION
# just-semver v0.5.0
## [0.5.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2022-06-11

### Done
* Add decimal version `DecVer` (`major.minor`) (#140)
  ```scala
  import just.decver.DecVer
  
  val decVer1 = DecVer.parse("1.17")
  // Either[DecVer.ParseError, DecVer] = Right(DecVer(1,17))
  
  decVer1.map(_.render)
  // Either[DecVer.ParseError, String] = Right(1.17)
  
  val decVer2 = DecVer.unsafeParse("1.17")
  // DecVer = DecVer(1,17)
  
  decVer2.render
  // String = 1.17
  
  val semVer = decVer2.toSemVer
  // just.semver.SemVer = SemVer(1,17,0,None,None)
  
  semVer.toDecVer
  // just.decver.DecVer = DecVer(1,17)
  
  DecVer.unsafeParse("1.16") < DecVer.unsafeParse("1.17")
  // Boolean = true
  
  DecVer.unsafeParse("1.16") == DecVer.unsafeParse("1.17")
  // Boolean = false
  
  DecVer.unsafeParse("1.16") > DecVer.unsafeParse("1.17")
  // Boolean = false
  
  val decVer = DecVer.unsafeParse("1.0")
  // DecVer = DecVer(1,0)
  
  decVer.increaseMinor
  // DecVer = DecVer(1,1)
  
  decVer.increaseMajor
  // DecVer = DecVer(2,0)
  ```
* Set up WartRemover for Scala 3 (#138)