### PR TITLE
just-semver v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,8 @@
+## [0.6.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2022-10-10
+
+## New Support
+* Support Scala.js (#160)
+
+## Internal Housekeeping
+* Create a doc site (#156) - https://just-semver.kevinly.dev
+* Modularize the project (#150)


### PR DESCRIPTION
# just-semver v0.6.0
## [0.6.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2022-10-10

## New Support
* Support Scala.js (#160)

## Internal Housekeeping
* Create a doc site (#156) - https://just-semver.kevinly.dev
* Modularize the project (#150)