### PR TITLE
Upgrade: sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,13 +4,13 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addSbtPlugin("org.scoverage"  % "sbt-scoverage"  % "2.0.6")
 addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"   % "0.10.4")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc"     % "2.3.6")
-addSbtPlugin("io.kevinlee"   % "sbt-docusaur" % "0.12.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc"     % "2.3.7")
+addSbtPlugin("io.kevinlee"   % "sbt-docusaur" % "0.13.0")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.11.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 
-val sbtDevOopsVersion = "2.23.0"
+val sbtDevOopsVersion = "2.24.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
Upgrade: sbt plugins
- sbt-mdoc to `2.3.7`
- sbt-docusaur to `0.13.0`
- sbt-devoops to `2.24.0`
