### PR TITLE
Update: build.sbt - Scala 3.0.0 => 3.0.2 / Hedgehog 0.10.1 for non Scala 3.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -14,11 +14,11 @@ align.tokens = [
     owners = [{
       regex = "Term.ApplyInfix"
     }]
-  }, {
-    code = ":="
-    owners = [{
-      regex = "Term.ApplyInfix",
-    }]
+//  }, {
+//    code = ":="
+//    owners = [{
+//      regex = "Term.ApplyInfix",
+//    }]
   }, {
     code = "->"
     owners = [{


### PR DESCRIPTION
# Summary
Update: build.sbt - Scala `3.0.0` => `3.0.2` / Hedgehog `0.10.1` for non Scala `3.0`
- Also change `.scalafmt.conf` to remove the rule for `:=`
