### PR TITLE
Close #187 - Bump sbt and Scala, and drop Scala 2.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,9 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2",   version: "2.11.12", binary-version: "2.11", java-version: "adopt@1.8",  params: "" }
-          - { name: "Scala 2",   version: "2.12.13", binary-version: "2.12", java-version: "adopt@1.11", params: "" }
-          - { name: "Scala 2",   version: "2.13.6",  binary-version: "2.13", java-version: "adopt@1.11", params: "" }
-          - { name: "Scala 3",   version: "3.0.0",   binary-version: "3",    java-version: "adopt@1.11", params: "" }
-          - { name: "Scala 3.1", version: "3.1.2",   binary-version: "3",    java-version: "adopt@1.11", params: '; set useAggressiveScalacOptions := true ;' }
+          - { name: "Scala 2",   version: "2.12.17", binary-version: "2.12", java-version: "adopt@1.11", params: "" }
+          - { name: "Scala 2",   version: "2.13.11", binary-version: "2.13", java-version: "adopt@1.11", params: "" }
+          - { name: "Scala 3.1", version: "3.1.3",   binary-version: "3",    java-version: "adopt@1.11", params: '; set useAggressiveScalacOptions := true ;' }
 
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +123,7 @@ jobs:
           echo "RUN_ID=${RUN_ID}"
           echo "RUN_NUMBER=${RUN_NUMBER}"
           export CI_BRANCH=$CURRENT_BRANCH_NAME
-          .github/workflows/sbt-build-all-with-coverage.sh 2.13.6
+          .github/workflows/sbt-build-all-with-coverage.sh 2.13.11
 
       - name: "[PR] Build with Test Coverage - PR-#${{ github.event.pull_request.number }} - ${{ github.run_number }}"
         if: github.event_name == 'pull_request'
@@ -141,7 +139,7 @@ jobs:
           echo "RUN_NUMBER=${RUN_NUMBER}"
           echo "PR #${PR_NUMBER}"
           echo "Rull request to the '${CURRENT_BRANCH_NAME}' branch"
-          .github/workflows/sbt-build-all-with-coverage.sh 2.13.6
+          .github/workflows/sbt-build-all-with-coverage.sh 2.13.11
 
       - if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.8", binary-version: "2.13", java-version: "adopt@1.11" }
+          - { version: "2.13.11", binary-version: "2.13", java-version: "adopt@1.11" }
         node:
           - { version: "16.16.0" }
 

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.8", binary-version: "2.13", java-version: "adopt@1.11" }
+          - { version: "2.13.11", binary-version: "2.13", java-version: "adopt@1.11" }
         node:
           - { version: "16.16.0" }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,9 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2",   version: "2.11.12", binary-version: "2.11", java-version: "adopt@1.8",  params: "" }
-          - { name: "Scala 2",   version: "2.12.13", binary-version: "2.12", java-version: "adopt@1.11", params: "" }
-          - { name: "Scala 2",   version: "2.13.6",  binary-version: "2.13", java-version: "adopt@1.11", params: "" }
-          - { name: "Scala 3",   version: "3.0.0",   binary-version: "3",    java-version: "adopt@1.11", params: "" }
-          - { name: "Scala 3.1", version: "3.1.2",   binary-version: "3",    java-version: "adopt@1.11", params: '; set useAggressiveScalacOptions := true ;' }
+          - { name: "Scala 2",   version: "2.12.17", binary-version: "2.12", java-version: "adopt@1.11", params: "" }
+          - { name: "Scala 2",   version: "2.13.11", binary-version: "2.13", java-version: "adopt@1.11", params: "" }
+          - { name: "Scala 3.1", version: "3.1.3",   binary-version: "3",    java-version: "adopt@1.11", params: '; set useAggressiveScalacOptions := true ;' }
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +53,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.6", binary-version: "2.13", java-version: "adopt@1.11" }
+          - { name: "Scala 2", version: "2.13.11", binary-version: "2.13", java-version: "adopt@1.11" }
 
     steps:
       - uses: actions/checkout@v4

--- a/build.sbt
+++ b/build.sbt
@@ -142,8 +142,8 @@ lazy val props =
     val isWartRemover: ModuleID => Boolean =
       m => m.name == "wartremover"
 
-    final val ProjectScalaVersion: String      = "3.1.2"
-//    final val ProjectScalaVersion: String     = "2.13.6"
+//    final val ProjectScalaVersion: String      = "3.1.3"
+    final val ProjectScalaVersion: String     = "2.13.11"
     final val CrossScalaVersions: List[String] =
       (
         if (isGhaPublishing)
@@ -152,10 +152,9 @@ lazy val props =
           identity[List[String]] _
       ) (
         List(
-          "2.11.12",
-          "2.12.13",
-          "2.13.6",
-          "3.0.2",
+          "2.12.17",
+          "2.13.11",
+          "3.1.3",
           ProjectScalaVersion
         ).distinct
       )
@@ -218,10 +217,8 @@ def module(projectName: String, crossProject: CrossProject.Builder): CrossProjec
           SemVer.majorMinorPatch(SemVer.parseUnsafe(scalaVersion.value)) match {
             case (Major(2), Minor(11), _) =>
               List(compilerPlugin("org.wartremover" %% "wartremover" % "2.4.19" cross CrossVersion.full))
-            case (Major(3), Minor(0), _) =>
-              List.empty[ModuleID]
             case (_, _, _) =>
-              List(compilerPlugin("org.wartremover" %% "wartremover" % "3.0.0" cross CrossVersion.full))
+              List(compilerPlugin("org.wartremover" %% "wartremover" % "3.1.4" cross CrossVersion.full))
           }
         }
       },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,14 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
-addSbtPlugin("org.scoverage"  % "sbt-scoverage"  % "2.0.6")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("org.scoverage"  % "sbt-scoverage"  % "2.0.9")
 addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"   % "0.10.4")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc"     % "2.3.7")
 addSbtPlugin("io.kevinlee"   % "sbt-docusaur" % "0.13.0")
 
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.11.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.13.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.1")
 
 val sbtDevOopsVersion = "2.24.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
Close #187 - Bump sbt and Scala, and drop Scala 2.11
- Bump sbt to `1.9.6`
- Bump Scala to
  - `2.12.17`
  - `2.13.11`
  - `3.1.3`
- Drop Scala `2.11` support
