### PR TITLE
just-semver v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,10 @@
+## [0.7.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2023-10-01
+
+## Internal Housekeeping
+* Bump sbt and Scala, and drop Scala `2.11` (#187)
+  * Bump sbt to `1.9.6`
+  * Bump Scala to
+    * `2.12.17`
+    * `2.13.11`
+    * `3.1.3`
+  * Drop Scala `2.11` support


### PR DESCRIPTION
# just-semver v0.7.0
## [0.7.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2023-10-01

## Internal Housekeeping
* Bump sbt and Scala, and drop Scala `2.11` (#187)
  * Bump sbt to `1.9.6`
  * Bump Scala to
    * `2.12.17`
    * `2.13.11`
    * `3.1.3`
  * Drop Scala `2.11` support
