### PR TITLE
just-semver v0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val coreJs  = core.js.settings(Test / fork := false)
 lazy val docs = (project in file("docs-gen-tmp/docs"))
   .enablePlugins(MdocPlugin, DocusaurPlugin)
   .settings(
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.11",
     name := prefixedProjectName("docs"),
     mdocIn := file("docs"),
     mdocOut := file("generated-docs/docs"),
@@ -146,10 +146,13 @@ lazy val props =
     final val ProjectScalaVersion: String     = "2.13.11"
     final val CrossScalaVersions: List[String] =
       (
-        if (isGhaPublishing)
-          (_: List[String]).diff(List(ProjectScalaVersion))
-        else
+        if (isGhaPublishing) {
+          // Publish version and the project version are the same so this logic is no longer required.
+          //          (_: List[String]).diff(List(ProjectScalaVersion))
           identity[List[String]] _
+        } else {
+          identity[List[String]] _
+        }
       ) (
         List(
           "2.12.17",

--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,14 @@
+## [0.9.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2023-10-01
+
+> NOTE: This release is exactly the same as `0.7.0` and `0.8.0`. 
+> 
+> `0.9.0` was released because `0.7.0` and `0.8.0` were not released properly.
+
+## Internal Housekeeping
+* Bump sbt and Scala, and drop Scala `2.11` (#187)
+  * Bump sbt to `1.9.6`
+  * Bump Scala to
+    * `2.12.17`
+    * `2.13.11`
+    * `3.1.3`
+  * Drop Scala `2.11` support


### PR DESCRIPTION
# just-semver v0.9.0
## [0.9.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2023-10-01

> NOTE: This release is exactly the same as `0.7.0` and `0.8.0`. 
> 
> `0.9.0` was released because `0.7.0` and `0.8.0` were not released properly.

## Internal Housekeeping
* Bump sbt and Scala, and drop Scala `2.11` (#187)
  * Bump sbt to `1.9.6`
  * Bump Scala to
    * `2.12.17`
    * `2.13.11`
    * `3.1.3`
  * Drop Scala `2.11` support
