### PR TITLE
just-semver v0.11.0

### DIFF
--- a/changelogs/0.11.0.md
+++ b/changelogs/0.11.0.md
@@ -1,0 +1,5 @@
+## [0.11.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11) - 2023-10-01
+
+## Internal Housekeeping
+* Bump bump Scala 3 to `3.3.0` (LTS) to solve #186 (#198)
+  * Bump Scala version to 3.3.0+ to avoid lazy val not working properly under GraalVM Native Image (#186)


### PR DESCRIPTION
# just-semver v0.11.0
## [0.11.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11) - 2023-10-01

## Internal Housekeeping
* Bump bump Scala 3 to `3.3.0` (LTS) to solve #186 (#198)
  * Bump Scala version to 3.3.0+ to avoid lazy val not working properly under GraalVM Native Image (#186)
