### PR TITLE
just-semver v0.12.0

### DIFF
--- a/changelogs/0.12.0.md
+++ b/changelogs/0.12.0.md
@@ -1,0 +1,4 @@
+## [0.12.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2023-10-01
+
+## Internal Housekeeping
+* Bump Scala 3 to `3.3.1` (LTS) (#202)


### PR DESCRIPTION
# just-semver v0.12.0
## [0.12.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2023-10-01

## Internal Housekeeping
* Bump Scala 3 to `3.3.1` (LTS) (#202)
