### PR TITLE
just-semver v0.13.0

### DIFF
--- a/changelogs/0.13.0.md
+++ b/changelogs/0.13.0.md
@@ -1,0 +1,4 @@
+## [0.13.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2023-10-12
+
+## New Feature
+* Support Scala Native (#208)


### PR DESCRIPTION
# just-semver v0.13.0
## [0.13.0](https://github.com/Kevin-Lee/just-semver/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2023-10-12

## New Feature
* Support Scala Native (#208)
