### PR TITLE
just-semver v1.0.0

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,48 @@
+## [1.0.0](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14) - 2024-08-26
+
+## New Feature
+
+
+* Add `just-semver-decver` module (#221)
+
+***
+* [`just-semver-decver`] Add `DecVerExt` which is `DecVer` with pre-release and build metadata (#223)
+
+***
+* Add `DecVerExtMatcher`, the matcher for `DecVerExt` (#225)
+  
+  ```scala
+  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("1.0")) // true
+  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("0.9")) // false
+  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("2.0")) // true
+  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("2.1")) // false
+  
+  // and more...
+  ```
+***
+
+* Replace `DecVer` with `DecVerExt`, and rename `DecVerExt` to `DecVer` (#230)
+***
+
+* Unable to parse version "25.1-jre-graal-sub-1" (#216)
+
+  ```scala
+  SemVer.parse("25.1-jre-graal-sub-1")
+  ```
+  Results in
+  ```
+  InvalidVersionStringError(25.1-jre-graal-sub-1)
+  ```
+  This can be handled by `DecVer` now.
+  ```scala
+  import just.decver.*
+  
+  DecVer.parse("25.1-jre-graal-sub-1")
+  // Either[DecVer.ParseError, DecVer] = Right(DecVer(Major(25),Minor(1),Some(PreRelease(List(Dsv(List(Alphabet(jre), Hyphen, Alphabet(graal), Hyphen, Alphabet(sub), Hyphen, Num(1)))))),None))
+  
+  val version = DecVer.unsafeParse("25.1-jre-graal-sub-1")
+  // DecVer = DecVer(Major(25),Minor(1),Some(PreRelease(List(Dsv(List(Alphabet(jre), Hyphen, Alphabet(graal), Hyphen, Alphabet(sub), Hyphen, Num(1)))))),None)
+  
+  version.render
+  // String = 25.1-jre-graal-sub-1
+  ```


### PR DESCRIPTION
# just-semver v1.0.0
## [1.0.0](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14) - 2024-08-26

## New Feature


* Add `just-semver-decver` module (#221)

***
* [`just-semver-decver`] Add `DecVerExt` which is `DecVer` with pre-release and build metadata (#223)

***
* Add `DecVerExtMatcher`, the matcher for `DecVerExt` (#225)
  
  ```scala
  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("1.0")) // true
  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("0.9")) // false
  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("2.0")) // true
  DecVerExtMatchers.unsafeParse("1.0 - 2.0").matches(DecVerExt.unsafeParse("2.1")) // false
  
  // and more...
  ```
***

* Replace `DecVer` with `DecVerExt`, and rename `DecVerExt` to `DecVer` (#230)
***

* Unable to parse version "25.1-jre-graal-sub-1" (#216)

  ```scala
  SemVer.parse("25.1-jre-graal-sub-1")
  ```
  Results in
  ```
  InvalidVersionStringError(25.1-jre-graal-sub-1)
  ```
  This can be handled by `DecVer` now.
  ```scala
  import just.decver.*
  
  DecVer.parse("25.1-jre-graal-sub-1")
  // Either[DecVer.ParseError, DecVer] = Right(DecVer(Major(25),Minor(1),Some(PreRelease(List(Dsv(List(Alphabet(jre), Hyphen, Alphabet(graal), Hyphen, Alphabet(sub), Hyphen, Num(1)))))),None))
  
  val version = DecVer.unsafeParse("25.1-jre-graal-sub-1")
  // DecVer = DecVer(Major(25),Minor(1),Some(PreRelease(List(Dsv(List(Alphabet(jre), Hyphen, Alphabet(graal), Hyphen, Alphabet(sub), Hyphen, Num(1)))))),None)
  
  version.render
  // String = 25.1-jre-graal-sub-1
  ```
