### PR TITLE
Fix #245 - `Dsv.parse` doesn't fail when the given input contains non-ascii or non-digit chars

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,7 +200,7 @@ lazy val props =
     val SonatypeCredentialHost = "s01.oss.sonatype.org"
     val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
-    final val HedgehogVersion = "0.9.0"
+    final val HedgehogVersion = "0.11.0"
 
     val HedgehogLatestVersion = "0.11.0"
 

--- a/modules/just-semver-core/shared/src/main/scala-2/just/semver/Dsv.scala
+++ b/modules/just-semver-core/shared/src/main/scala-2/just/semver/Dsv.scala
@@ -30,7 +30,7 @@ object Dsv extends Compat {
     def accumulate(cs: List[Char], chars: Anh, acc: Vector[Anh]): Either[DsvParseError, Vector[Anh]] =
       cs match {
         case x :: xs =>
-          if (x.isDigit) {
+          if (x >= '0' && x <= '9') {
             chars match {
               case Num(ns) =>
                 accumulate(xs, Num(ns :+ x), acc)
@@ -40,7 +40,7 @@ object Dsv extends Compat {
             }
           } else if (x === '-') {
             accumulate(xs, Hyphen, acc :+ chars)
-          } else if (x.isUpper || x.isLower) {
+          } else if ((x >= 'A' && x <= 'Z') || (x >= 'a' && x <= 'z')) {
             chars match {
               case Alphabet(as) =>
                 accumulate(xs, Alphabet(as :+ x), acc)
@@ -61,11 +61,11 @@ object Dsv extends Compat {
     value.toList match {
       case x :: xs =>
         val result =
-          if (x.isDigit) {
+          if (x >= '0' && x <= '9') {
             accumulate(xs, Num(x.toString), Vector.empty)
           } else if (x === '-')
             accumulate(xs, Hyphen, Vector.empty)
-          else if (x.isLower || x.isUpper)
+          else if ((x >= 'A' && x <= 'Z') || (x >= 'a' && x <= 'z'))
             accumulate(xs, Alphabet(x.toString), Vector.empty)
           else
             Left(

--- a/modules/just-semver-core/shared/src/main/scala-3/just/semver/Dsv.scala
+++ b/modules/just-semver-core/shared/src/main/scala-3/just/semver/Dsv.scala
@@ -26,7 +26,7 @@ object Dsv extends Compat {
     def accumulate(cs: List[Char], chars: Anh, acc: Vector[Anh]): Either[DsvParseError, Vector[Anh]] =
       cs match {
         case x :: xs =>
-          if (x.isDigit) {
+          if (x >= '0' && x <= '9') {
             chars match {
               case Num(ns) =>
                 accumulate(xs, Num(ns :+ x), acc)
@@ -36,7 +36,7 @@ object Dsv extends Compat {
             }
           } else if (x === '-') {
             accumulate(xs, Hyphen, acc :+ chars)
-          } else if (x.isUpper || x.isLower) {
+          } else if ((x >= 'A' && x <= 'Z') || (x >= 'a' && x <= 'z')) {
             chars match {
               case Alphabet(as) =>
                 accumulate(xs, Alphabet(as :+ x), acc)
@@ -57,11 +57,11 @@ object Dsv extends Compat {
     value.toList match {
       case x :: xs =>
         val result =
-          if (x.isDigit) {
+          if (x >= '0' && x <= '9') {
             accumulate(xs, Num(x.toString), Vector.empty)
           } else if (x === '-')
             accumulate(xs, Hyphen, Vector.empty)
-          else if (x.isLower || x.isUpper)
+          else if ((x >= 'A' && x <= 'Z') || (x >= 'a' && x <= 'z'))
             accumulate(xs, Alphabet(x.toString), Vector.empty)
           else
             Left(

--- a/modules/just-semver-core/shared/src/test/scala/just/semver/DsvSpec.scala
+++ b/modules/just-semver-core/shared/src/test/scala/just/semver/DsvSpec.scala
@@ -11,7 +11,7 @@ import scala.collection.compat.immutable._
 object DsvSpec extends Properties {
   override def tests: List[Test] = List(
     property("test Dsv.parse(valid String)", testParse),
-    property("test Dsv.parse(invalid String)", testParseInvalid),
+    property("test Dsv.parse(invalid String)", testParseInvalid).withTests(20000).noShrinking,
     example("test Dsv.parse(an empty String)", testParseInvalid2),
   )
 
@@ -139,13 +139,13 @@ object DsvSpec extends Properties {
              ),
              Range.linear(1, 3)
            )
-           .map(_.mkString)
            .log("s")
   } yield {
     val actual = Dsv.parse(s)
     (actual ==== Left(Dsv.DsvParseError.invalidAlphaNumHyphenError(s.head, s.tail.toList)))
       .log(
-        s"s=${s.map(_.toInt).mkString("[", ", ", "]")}"
+        s">>> Invalid char detection failed: " +
+          s"s=$s / Int=${s.map(_.toInt).mkString("[", ", ", "]")} / unicode=${s.map(c => "\\u%04x".format(c.toInt)).mkString}"
       )
   }
 

--- a/modules/just-semver-decver/shared/src/main/scala-2/just/decver/DecVer.scala
+++ b/modules/just-semver-decver/shared/src/main/scala-2/just/decver/DecVer.scala
@@ -228,7 +228,7 @@ object DecVer extends Compat {
     def render(decVerError: ParseError): String = decVerError match {
       case ParseError.NullValue => "Version String is null"
       case ParseError.Empty => "Version String is an empty String"
-      case ParseError.Invalid(version) => s"Invalue version: $version"
+      case ParseError.Invalid(version) => s"Invalid version: $version"
 
       case InvalidAlphaNumHyphenError(c, rest) =>
         s"Invalid char for AlphaNumHyphen found. value: ${c.toString} / rest: ${rest.toString}"

--- a/modules/just-semver-decver/shared/src/main/scala-3/just/decver/DecVer.scala
+++ b/modules/just-semver-decver/shared/src/main/scala-3/just/decver/DecVer.scala
@@ -220,7 +220,7 @@ object DecVer extends Compat {
       def render: String = decVerError match {
         case ParseError.NullValue => "Version String is null"
         case ParseError.Empty => "Version String is an empty String"
-        case ParseError.Invalid(version) => s"Invalue version: $version"
+        case ParseError.Invalid(version) => s"Invalid version: $version"
 
         case InvalidAlphaNumHyphenError(c, rest) =>
           s"Invalid char for AlphaNumHyphen found. value: ${c.toString} / rest: ${rest.toString}"


### PR DESCRIPTION
# Summary
Fix #245 - `Dsv.parse` doesn't fail when the given input contains non-ascii or non-digit chars