### PR TITLE
just-semver v1.1.1

### DIFF
--- a/changelogs/1.1.1.md
+++ b/changelogs/1.1.1.md
@@ -1,0 +1,5 @@
+## [1.1.1](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Amilestone16) - 2025-03-30
+
+## Fixed
+
+* Fix: `Dsv.parse` doesn't fail when the given input contains non-ascii or non-digit chars (#245)

--- a/modules/just-semver-core/shared/src/test/scala/just/semver/DsvSpec.scala
+++ b/modules/just-semver-core/shared/src/test/scala/just/semver/DsvSpec.scala
@@ -126,20 +126,29 @@ object DsvSpec extends Properties {
     }
     .toList
 
-  private val someNonAnhChars = someNonAnhCharInts
-    .map { case (start, end) => start.toChar -> end.toChar }
+//  private val someNonAnhChars = someNonAnhCharInts
+//    .map { case (start, end) => start.toChar -> end.toChar }
 
   @SuppressWarnings(Array("org.wartremover.warts.IterableOps", "org.wartremover.warts.ToString"))
   def testParseInvalid: Property = for {
-    s <- Gen
-           .string(
-             Gen.choice(
-               (Gen.char _).tupled(someNonAnhChars.head),
-               someNonAnhChars.tail.map { case (start, end) => Gen.char(start, end) }
-             ),
-             Range.linear(1, 3)
-           )
-           .log("s")
+    charInt <- Gen
+                 .choice(
+                   Gen.int((Range.linear[Int] _).tupled(someNonAnhCharInts.head)),
+                   someNonAnhCharInts.tail.map { case (start, end) => Gen.int(Range.linear[Int](start, end)) }
+                 )
+                 .list(Range.linear(1, 3))
+                 .log("charInt")
+//    _ = println(s"charInt=${charInt.mkString("[", ", ", "]")}")
+    s       <- Gen.constant(charInt.map(_.toChar).mkString).log("s")
+//    s <- Gen
+//           .string(
+//             Gen.choice(
+//               (Gen.char _).tupled(someNonAnhChars.head),
+//               someNonAnhChars.tail.map { case (start, end) => Gen.char(start, end) }
+//             ),
+//             Range.linear(1, 3)
+//           )
+//           .log("s")
   } yield {
     val actual = Dsv.parse(s)
     (actual ==== Left(Dsv.DsvParseError.invalidAlphaNumHyphenError(s.head, s.tail.toList)))


### PR DESCRIPTION
# just-semver v1.1.1
## [1.1.1](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Amilestone16) - 2025-03-30

## Fixed

* Fix: `Dsv.parse` doesn't fail when the given input contains non-ascii or non-digit chars (#245)
