### PR TITLE
Update `.gitignore` to exclude Metals configuration files and Bloop configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+project/**/metals.sbt
 generated-docs*/
 docs-gen-tmp/
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 project/**/metals.sbt
+.bloop/
 generated-docs*/
 docs-gen-tmp/
 


### PR DESCRIPTION
# Summary
Update `.gitignore` to exclude Metals configuration files and Bloop configuration files