### PR TITLE
Update website dependencies and browser targets

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -15,19 +15,19 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.5.2",
-    "@docusaurus/preset-classic": "3.5.2",
+    "@docusaurus/core": "3.8.1",
+    "@docusaurus/preset-classic": "3.8.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.5.2",
-    "@docusaurus/tsconfig": "3.5.2",
-    "@docusaurus/types": "3.5.2",
-    "typescript": "~5.5.2"
+    "@docusaurus/module-type-aliases": "3.8.1",
+    "@docusaurus/tsconfig": "3.8.1",
+    "@docusaurus/types": "3.8.1",
+    "typescript": "~5.6.2"
   },
   "browserslist": {
     "production": [
@@ -36,9 +36,9 @@
       "not op_mini all"
     ],
     "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
+      "last 3 chrome version",
+      "last 3 firefox version",
+      "last 5 safari version"
     ]
   },
   "engines": {


### PR DESCRIPTION
# Summary
Update website dependencies and browser targets

- Upgrade Docusaurus packages from 3.5.2 to 3.8.1
- Upgrade React and React DOM from 18.0.0 to 19.0.0
- Upgrade TypeScript from 5.5.2 to 5.6.2
- Expand browser compatibility targets for development:
  - Chrome and Firefox from last 1 version to last 3 versions
  - Safari from last 1 version to last 5 versions
