### PR TITLE
Update GitHub Actions: Bump Node from 18.13.0 to 22.17.0 in doc site build

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -15,7 +15,7 @@ jobs:
         scala:
           - { version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "18.13.0" }
+          - { version: "22.17.0" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -14,7 +14,7 @@ jobs:
         scala:
           - { version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "18.13.0" }
+          - { version: "22.17.0" }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Summary
Update GitHub Actions: Bump Node from 18.13.0 to 22.17.0 in doc site build