### PR TITLE
Bump hedgehog to 0.13.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   GH_SBT_OPTS: "-Xss64m -Xms1024m -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
-  GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
 
 jobs:
 
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2.13", version: "2.13.16", binary-version: "2.13", java-version: "17", java-distribution: "liberica", report: "report" }
+          - { name: "Scala 2.13", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 env:
   GH_JAVA_VERSION: "11"
   GH_JAVA_DISTRIBUTION: "temurin"
-  GH_JVM_OPTS: "-Xss64m -Xms1024m -XX:MaxMetaspaceSize=1G -Xmx2G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  GH_JVM_OPTS: "-Xss64m -Xms1024m -XX:MaxMetaspaceSize=1G -Xmx2G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
 
 jobs:
 

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val core = module("core", crossProject(JVMPlatform, JSPlatform, NativePlatf
   )
 
 lazy val coreJvm = core.jvm
-lazy val coreJs  = core.js.settings(Test / fork := false)
+lazy val coreJs  = core.js.settings(jsSettings)
 
 lazy val coreNative = core.native.settings(nativeSettings)
 
@@ -97,7 +97,7 @@ lazy val decver = module("decver", crossProject(JVMPlatform, JSPlatform, NativeP
   .dependsOn(core % props.IncludeTest)
 
 lazy val decverJvm = decver.jvm
-lazy val decverJs  = decver.js.settings(Test / fork := false)
+lazy val decverJs  = decver.js.settings(jsSettings)
 
 lazy val decverNative = decver.native.settings(nativeSettings)
 
@@ -193,9 +193,7 @@ lazy val props =
 
     val IncludeTest = "compile->compile;test->test"
 
-    final val HedgehogVersion = "0.11.0"
-
-    val HedgehogLatestVersion = "0.11.0"
+    val HedgehogVersion = "0.13.0"
 
     val ScalaCollectionCompatVersion = "2.13.0"
 
@@ -208,11 +206,7 @@ lazy val libs =
 
       lazy val hedgehogLibs = Def.setting {
         val scalaV          = scalaVersion.value
-        val hedgehogVersion =
-          if (scalaV.startsWith("3.0"))
-            props.HedgehogVersion
-          else
-            props.HedgehogLatestVersion
+        val hedgehogVersion = props.HedgehogVersion
 
         List(
           "qa.hedgehog" %%% "hedgehog-core"   % hedgehogVersion % Test,
@@ -312,6 +306,12 @@ def module(projectName: String, crossProject: CrossProject.Builder): CrossProjec
     )
 }
 
+lazy val jsSettings: SettingsDefinition = List(
+  Test / fork := false,
+  coverageEnabled := false
+)
+
 lazy val nativeSettings: SettingsDefinition = List(
-  Test / fork := false
+  Test / fork := false,
+  coverageEnabled := false
 )

--- a/modules/just-semver-core/shared/src/main/scala-2/just/semver/ParseError.scala
+++ b/modules/just-semver-core/shared/src/main/scala-2/just/semver/ParseError.scala
@@ -90,7 +90,7 @@ object ParseError {
   }
 
   implicit final class ParseErrorOps(private val parseError: ParseError) extends AnyVal {
-    @inline def render: String = ParseError.render(parseError)
+    def render: String = just.semver.ParseError.render(parseError)
   }
 
 }


### PR DESCRIPTION
# Summary
Bump hedgehog to 0.13.0
- Also update: build.sbt to fix the broken build due to test coverage check for Scala.js and Scala Native