### PR TITLE
just-semver v1.2.0

### DIFF
--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,0 +1,7 @@
+## [1.2.0](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am17) - 2026-02-21
+
+### New Support
+
+* Upgrade `Scala.js` to `1.19.0` (#269)
+  
+  > ***Note:*** This may break builds with older versions of `Scala.js`.


### PR DESCRIPTION
# just-semver v1.2.0
## [1.2.0](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am17) - 2026-02-21

### New Support

* Upgrade `Scala.js` to `1.19.0` (#269)
  
  > ***Note:*** This may break builds with older versions of `Scala.js`.
