### PR TITLE
just-semver v1.3.0

### DIFF
--- a/changelogs/1.3.0.md
+++ b/changelogs/1.3.0.md
@@ -1,0 +1,12 @@
+## [1.3.0](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am18) - 2026-02-21
+
+### New Support
+
+* Upgrade Scala.js to 1.20.0 (#272)
+
+  > ***Note:*** This may break builds with older versions of `Scala.js`.
+
+
+## Internal Housekeeping
+
+* Move the docs to a separate repository (#273)


### PR DESCRIPTION
# just-semver v1.3.0
## [1.3.0](https://github.com/Kevin-Lee/just-semver/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am18) - 2026-04-27

### New Support

* Upgrade Scala.js to 1.20.0 (#272)

  > ***Note:*** This may break builds with older versions of `Scala.js`.


## Internal Housekeeping

* Move the docs to a separate repository (#273)
