### PR TITLE
Bump sbt to 1.12.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -263,14 +263,4 @@ lazy val jsSettings: SettingsDefinition = List(
 lazy val nativeSettings: SettingsDefinition = List(
   Test / fork := false,
   coverageEnabled := false
-) ++ List(
-  dependencyOverrides ++= {
-    import just.semver.SemVer
-    libraryDependencies.value.collect {
-      case dep
-          if dep.organization == "org.scala-native" &&
-            SemVer.parse(dep.revision).exists(_ >= SemVer.parseUnsafe("0.5.0")) =>
-        dep
-    }
-  }
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.10
+sbt.version=1.12.11


### PR DESCRIPTION
# Bump sbt to `1.12.11`

* Update `build.sbt`: Remove Scala Native dependency overrides - no longer required since sbt 1.12.11 fixed the issue that required it